### PR TITLE
use non OS folder separator in webapp paths

### DIFF
--- a/src/main/java/io/keikai/tutorial/Configuration.java
+++ b/src/main/java/io/keikai/tutorial/Configuration.java
@@ -27,6 +27,6 @@ public class Configuration {
     }
 
     static public String getDefaultFileFolder(){
-        return "/WEB-INF" + File.separator + Configuration.INTERNAL_FILE_FOLDER + File.separator;
+        return "/WEB-INF/" + INTERNAL_FILE_FOLDER + "/";
     }
 }


### PR DESCRIPTION
context internal paths only contain forward slashes